### PR TITLE
[Feat] #2 네트워크 레이어 구현

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,10 +5,10 @@
 disabled_rules:
   - todo # TODO 주석을 에러로 처리하지 않음
   - trailing_comma # 마지막 콤마를 강제하지 않음
+  - trailing_whitespace
 
 # 기본적으로 비활성화된 규칙 중, 가이드에 따라 활성화할 규칙들을 명시합니다.
 opt_in_rules:
-  - explicit_self # 클래스와 구조체 내에서 'self' 사용을 강제 (가이드: 'self'를 명시적으로 사용)
   - trailing_closure # 클로저를 마지막 파라미터로 받을 때, 파라미터 이름 생략 (가이드: Closure 호출 규칙)
   - closure_parameter_position # 클로저 파라미터는 괄호 바깥에 위치 (가이드: 클로저 파라미터 괄호 미사용)
   - redundant_type_annotation # 불필요한 타입 정의 생략 (가이드: 클로저 타입 정의 생략)
@@ -17,7 +17,6 @@ opt_in_rules:
   - legacy_cggeometry_functions # CGRectMake 대신 CGRect 사용 (가이드: 구조체 생성자)
   - mark # '// MARK:' 주석 형식 검사 (가이드: 주석 규칙)
   - trailing_newline # 모든 파일은 빈 줄로 끝나도록 강제 (가이드: 빈 줄 규칙)
-  - final_where_possible # 상속되지 않는 클래스에 final 키워드 사용 권장 (가이드: final 키워드)
 
 # 개별 규칙에 대한 상세 설정
 # 가이드에 명시된 내용을 중심으로 설정합니다.
@@ -30,9 +29,6 @@ line_length:
   ignores_comments: true
   ignores_urls: true
 
-trailing_whitespace: # 빈 줄이나 코드 끝의 공백 비허용
-  ignores_empty_lines: false
-
 colon: # 콜론(:)은 오른쪽에만 공백
   flexible_right_spacing: false
 
@@ -40,6 +36,8 @@ colon: # 콜론(:)은 오른쪽에만 공백
 type_name: # 클래스, 구조체, 열거형, 프로토콜 이름은 UpperCamelCase
   min_length: 3
   max_length: 40
+  excluded:
+    - "^iTunes[A-Z].*"
 
 identifier_name: # 변수, 상수, 함수, 열거형 case 이름은 lowerCamelCase
   min_length: 2
@@ -65,3 +63,10 @@ function_body_length:
 file_length:
   warning: 500
   error: 800
+
+excluded:
+  - iTunesStore/AppDelegate.swift
+  - iTunesStore/SceneDelegate.swift
+
+analyzer_rules:
+  - explicit_self

--- a/iTunesStore.xcodeproj/project.pbxproj
+++ b/iTunesStore.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		B531535E2E3795BF00F138B5 /* SwiftLint Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/iTunesStore/Data/DTO/MovieDTO.swift
+++ b/iTunesStore/Data/DTO/MovieDTO.swift
@@ -1,0 +1,42 @@
+//
+//  MovieDTO.swift
+//  iTunesStore
+//
+//  Created by Milou on 7/30/25.
+//
+
+import Foundation
+
+struct MovieResponseDTO: Decodable {
+  let resultCount: Int
+  let results: [MovieDTO]
+}
+
+struct MovieDTO: Decodable {
+  let trackId: Int
+  let artistName: String
+  let collectionName: String
+  let trackName: String
+  let artworkUrl100: String
+  let artworkUrl600: String?
+  let primaryGenreName: String?
+  let contentAdvisoryRating: String?
+  let releaseDate: Date?
+  
+  var artworkUrl: String {
+      return artworkUrl600 ?? artworkUrl100
+    }
+  
+  func toEntity() -> Movie {
+    return Movie(
+      id: trackId,
+      artistName: artistName,
+      collectionName: collectionName,
+      trackName: trackName,
+      artworkUrl: artworkUrl,
+      genre: primaryGenreName,
+      contentRating: contentAdvisoryRating,
+      releaseDate: releaseDate
+    )
+  }
+}

--- a/iTunesStore/Data/DTO/MusicDTO.swift
+++ b/iTunesStore/Data/DTO/MusicDTO.swift
@@ -1,0 +1,38 @@
+//
+//  MusicDTO.swift
+//  iTunesStore
+//
+//  Created by Milou on 7/30/25.
+//
+
+import Foundation
+
+struct MusicResponseDTO: Decodable {
+  let resultCount: Int
+  let results: [MusicDTO]
+}
+
+struct MusicDTO: Decodable {
+  let trackId: Int
+  let artistName: String
+  let collectionName: String?
+  let trackName: String
+  let artworkUrl100: String
+  let artworkUrl600: String?
+  let primaryGenreName: String?
+  
+  var artworkUrl: String {
+      return artworkUrl600 ?? artworkUrl100
+    }
+  
+  func toEntity() -> Music {
+    return Music(
+      id: trackId,
+      artistName: artistName,
+      albumName: collectionName ?? "Unknown Album",
+      trackName: trackName,
+      artworkUrl: artworkUrl,
+      genre: primaryGenreName
+    )
+  }
+}

--- a/iTunesStore/Data/DTO/PodcastDTO.swift
+++ b/iTunesStore/Data/DTO/PodcastDTO.swift
@@ -1,0 +1,42 @@
+//
+//  PodcastDTO.swift
+//  iTunesStore
+//
+//  Created by Milou on 7/30/25.
+//
+
+import Foundation
+
+struct PodcastResponseDTO: Decodable {
+  let resultCount: Int
+  let results: [PodcastDTO]
+}
+
+struct PodcastDTO: Decodable {
+  let trackId: Int
+  let artistName: String
+  let collectionName: String
+  let trackName: String
+  let artworkUrl100: String
+  let artworkUrl600: String?
+  let primaryGenreName: String?
+  let genres: [String]
+  let releaseDate: Date?
+  
+  var artworkUrl: String {
+      return artworkUrl600 ?? artworkUrl100
+    }
+  
+  func toEntity() -> Podcast {
+    return Podcast(
+      id: trackId,
+      artistName: artistName,
+      collectionName: collectionName,
+      trackName: trackName,
+      artworkUrl: artworkUrl,
+      genre: primaryGenreName,
+      genres: genres,
+      releaseDate: releaseDate
+    )
+  }
+}

--- a/iTunesStore/Data/Network/APIEndpoint.swift
+++ b/iTunesStore/Data/Network/APIEndpoint.swift
@@ -1,0 +1,61 @@
+//
+//  APIEndpoint.swift
+//  iTunesStore
+//
+//  Created by Milou on 7/29/25.
+//
+
+import Foundation
+
+protocol APIEndpoint {
+  var baseURL: String { get }
+  var path: String { get }
+  var parameters: [String: String] { get }
+}
+
+extension APIEndpoint {
+  var url: URL? {
+    var components = URLComponents(string: baseURL + path)
+    
+    if !parameters.isEmpty {
+      components?.queryItems = parameters.map {
+        URLQueryItem(name: $0.key, value: $0.value)
+      }
+    }
+    return components?.url
+  }
+}
+
+enum iTunesEndpoint: APIEndpoint {
+  case seasonMusic(season: SeasonType)
+  case searchMovies(term: String)
+  case searchPodcasts(term: String)
+  
+  var baseURL: String {
+    return "https://itunes.apple.com"
+  }
+  
+  var path: String {
+    return "/search"
+  }
+  
+  var parameters: [String : String] {
+    var params = ["lang": "ko_KR"]
+    
+    switch self {
+    case .seasonMusic(let season):
+      params["term"] = season.rawValue
+      params["media"] = MediaType.music.rawValue
+      
+    case .searchMovies(term: let term):
+      params["term"] = term
+      params["media"] = MediaType.movie.rawValue
+      
+    case .searchPodcasts(term: let term):
+      params["term"] = term
+      params["media"] = MediaType.podcast.rawValue
+    }
+    
+    return params
+  }
+}

--- a/iTunesStore/Data/Network/APIEndpoint.swift
+++ b/iTunesStore/Data/Network/APIEndpoint.swift
@@ -39,7 +39,7 @@ enum iTunesEndpoint: APIEndpoint {
     return "/search"
   }
   
-  var parameters: [String : String] {
+  var parameters: [String: String] {
     var params = ["lang": "ko_KR"]
     
     switch self {

--- a/iTunesStore/Data/Network/NetworkError.swift
+++ b/iTunesStore/Data/Network/NetworkError.swift
@@ -1,0 +1,15 @@
+//
+//  NetworkError.swift
+//  iTunesStore
+//
+//  Created by Milou on 7/30/25.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+  case invalidURL
+  case invalidStatusCode(Int)
+  case decodingError(description: String)
+  case unknown
+}

--- a/iTunesStore/Data/Network/NetworkService.swift
+++ b/iTunesStore/Data/Network/NetworkService.swift
@@ -1,0 +1,11 @@
+//
+//  NetworkService.swift
+//  iTunesStore
+//
+//  Created by Milou on 7/30/25.
+//
+import RxSwift
+
+protocol NetworkService {
+  func fetch<T: Decodable>(endPoint: APIEndpoint) -> Single<T>
+}

--- a/iTunesStore/Data/Network/NetworkServiceImp.swift
+++ b/iTunesStore/Data/Network/NetworkServiceImp.swift
@@ -1,0 +1,46 @@
+//
+//  NetworkServiceImp.swift
+//  iTunesStore
+//
+//  Created by Milou on 7/30/25.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class NetworkServiceImp: NetworkService {
+  private let urlSession: URLSession
+  
+  init(urlSession: URLSession = .shared) {
+    self.urlSession = urlSession
+  }
+  
+  func fetch<T>(endPoint: any APIEndpoint) -> Single<T> where T: Decodable {
+    guard let url = endPoint.url else {
+      return .error(NetworkError.invalidURL)
+    }
+    
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    
+    return URLSession.shared.rx.data(request: request)
+      .asSingle()
+      .map { data in
+        do {
+          let decodedData = try JSONDecoder().decode(T.self, from: data)
+          return decodedData
+        } catch {
+          print("🥵 Decoding Error: \(error)")
+          throw NetworkError.decodingError(description: error.localizedDescription)
+        }
+      }
+      .catch { error in
+        if let urlError = error as? URLError {
+          throw NetworkError.invalidStatusCode(urlError.errorCode)
+        }
+        throw NetworkError.unknown
+      }
+  }
+}

--- a/iTunesStore/Domain/Entity/MediaType.swift
+++ b/iTunesStore/Domain/Entity/MediaType.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum MediaType: String, CaseIterable {
-  case music = "music"
-  case podcast = "podcast"
-  case movie = "movie"
+  case music
+  case podcast
+  case movie
 }

--- a/iTunesStore/Domain/Entity/Music.swift
+++ b/iTunesStore/Domain/Entity/Music.swift
@@ -11,7 +11,7 @@ struct Music {
   let id: Int // trackId
   let mediaType: MediaType = .music
   let artistName: String
-  let collectionName: String
+  let albumName: String? // collectionName
   let trackName: String
   let artworkUrl: String // artworkUrl100
   let genre: String? // primaryGenreName

--- a/iTunesStore/ViewController.swift
+++ b/iTunesStore/ViewController.swift
@@ -6,13 +6,33 @@
 //
 
 import UIKit
+import RxSwift
 
 class ViewController: UIViewController {
-
+  private let disposeBag = DisposeBag()
+  
   override func viewDidLoad() {
-    super.viewDidLoad()
-    // Do any additional setup after loading the view.
-    view.backgroundColor = .brown
+      super.viewDidLoad()
+      testNetworkService()
+    }
+  
+  private func testNetworkService() {
+    let networkService = NetworkServiceImp()
+    let endpoint = iTunesEndpoint.seasonMusic(season: .spring)
+    
+    networkService.fetch(endPoint: endpoint)
+      .observe(on: MainScheduler.instance)
+      .subscribe(
+        onSuccess: { (response: MusicResponseDTO) in
+          print("✅ Success: \(response.results.count)개의 음악")
+          response.results.forEach { music in
+            print("- \(music.trackName) by \(music.artistName)")
+          }
+        },
+        onFailure: { error in
+          print("❌ Error: \(error.localizedDescription)")
+        }
+      )
+      .disposed(by: disposeBag)
   }
-
 }


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #2

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- Data/DTO: 각 엔티티에 따른 응답 모델 정의 및 toEntity() 구현
  - 각 미디어 타입의 중복 코드가 많아 공통 엔티티/DTO로 리팩토링하는 것을 고민중
- APIEndpoint.swift: 공통 API Endpoint 프로토콜 정의 및 iTunes API 요청을 위한 iTunesEndpoint enum 구현
- NetworkService.swift: 제네릭 타입으로 Decodable 객체를 반환하는 fetch() 메서드 정의
- NetworkServiceImp.swift: NetworkService 구현체, RxSwift/RxCocoa 기반 네트워크 요청 처리
<br>
