### PR TITLE
[Feat] #8 상세페이지 구현

### DIFF
--- a/iTunesStore.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iTunesStore.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cde5f69117d2309b57c4feda0d3054570a3121502d2bbdce73396039974d4a1b",
+  "originHash" : "d6e52728d180eeb81f38623cdeed8ee63a117750c3fe88b136756d75d3ddd3f1",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/iTunesStore/Core/AppCoordinator.swift
+++ b/iTunesStore/Core/AppCoordinator.swift
@@ -46,6 +46,19 @@ final class AppCoordinator {
      navigationController?.popViewController(animated: true)
    }
   
+  func showDetailScreen(mediaItem: MediaItem) {
+    let detailViewController = DetailViewController(
+      mediaItem: mediaItem,
+      coordinator: self
+    )
+    detailViewController.modalPresentationStyle = .fullScreen
+    navigationController?.present(detailViewController, animated: true)
+  }
+  
+  func dismissDetailScreen() {
+    navigationController?.dismiss(animated: true)
+  }
+  
   // MARK: - Error Handling
   
   func showErrorAlert(_ error: Error, from viewController: UIViewController? = nil) {

--- a/iTunesStore/Data/DTO/MovieDTO.swift
+++ b/iTunesStore/Data/DTO/MovieDTO.swift
@@ -20,8 +20,9 @@ struct MovieDTO: Decodable {
   let artworkUrl100: String
   let artworkUrl600: String?
   let primaryGenreName: String?
-  let contentAdvisoryRating: String?
   let releaseDate: String?
+  let contentAdvisoryRating: String?
+  let longDescription: String?
   
   var artworkUrl: String {
       return artworkUrl600 ?? artworkUrl100
@@ -35,8 +36,9 @@ struct MovieDTO: Decodable {
       trackName: trackName,
       artworkUrl: artworkUrl,
       genre: primaryGenreName,
+      releaseDate: releaseDate,
       contentRating: contentAdvisoryRating,
-      releaseDate: releaseDate
+      longDescription: longDescription
     )
   }
 }

--- a/iTunesStore/Data/DTO/MusicDTO.swift
+++ b/iTunesStore/Data/DTO/MusicDTO.swift
@@ -20,6 +20,7 @@ struct MusicDTO: Decodable {
   let artworkUrl100: String
   let artworkUrl600: String?
   let primaryGenreName: String?
+  let releaseDate: String?
   
   var artworkUrl: String {
       return artworkUrl600 ?? artworkUrl100
@@ -32,7 +33,8 @@ struct MusicDTO: Decodable {
       albumName: collectionName ?? "Unknown Album",
       trackName: trackName,
       artworkUrl: artworkUrl,
-      genre: primaryGenreName
+      genre: primaryGenreName,
+      releaseDate: releaseDate
     )
   }
 }

--- a/iTunesStore/Data/DTO/PodcastDTO.swift
+++ b/iTunesStore/Data/DTO/PodcastDTO.swift
@@ -20,8 +20,8 @@ struct PodcastDTO: Decodable {
   let artworkUrl100: String
   let artworkUrl600: String?
   let primaryGenreName: String?
-  let genres: [String]
   let releaseDate: String?
+  let genres: [String]
   
   var artworkUrl: String {
       return artworkUrl600 ?? artworkUrl100
@@ -35,8 +35,8 @@ struct PodcastDTO: Decodable {
       trackName: trackName,
       artworkUrl: artworkUrl,
       genre: primaryGenreName,
-      genres: genres,
-      releaseDate: releaseDate
+      releaseDate: releaseDate,
+      genres: genres
     )
   }
 }

--- a/iTunesStore/Domain/Entity/Movie.swift
+++ b/iTunesStore/Domain/Entity/Movie.swift
@@ -15,7 +15,8 @@ struct Movie: MediaItem {
   let trackName: String
   let artworkUrl: String // artworkUrl100
   let genre: String? // primaryGenreName
+  let releaseDate: String?
   
   let contentRating: String? // contentAdvisoryRating
-  let releaseDate: String?
+  let longDescription: String?
 }

--- a/iTunesStore/Domain/Entity/Music.swift
+++ b/iTunesStore/Domain/Entity/Music.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Music {
+struct Music: MediaItem {
   let id: Int  // trackId
   let mediaType: MediaType = .music
   let artistName: String
@@ -15,4 +15,9 @@ struct Music {
   let trackName: String
   let artworkUrl: String  // artworkUrl100
   let genre: String?  // primaryGenreName
+  let releaseDate: String?
+  
+  var collectionName: String {
+    return albumName ?? "Unknown Album"
+  }
 }

--- a/iTunesStore/Domain/Entity/Podcast.swift
+++ b/iTunesStore/Domain/Entity/Podcast.swift
@@ -15,7 +15,7 @@ struct Podcast: MediaItem {
   let trackName: String
   let artworkUrl: String // artworkUrl100
   let genre: String? // primaryGenreName
+  let releaseDate: String?
   
   let genres: [String]
-  let releaseDate: String?
 }

--- a/iTunesStore/Presentation/Views/DetailViewController.swift
+++ b/iTunesStore/Presentation/Views/DetailViewController.swift
@@ -1,0 +1,225 @@
+//
+//  DetailViewController.swift
+//  iTunesStore
+//
+//  Created by Milou on 8/4/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import SnapKit
+import Then
+
+final class DetailViewController: UIViewController {
+  
+  // MARK: - Properties
+  
+  private let mediaItem: MediaItem
+  weak var coordinator: AppCoordinator?
+  private let disposeBag = DisposeBag()
+  
+  // MARK: - UI Components
+  
+  private let scrollView = UIScrollView()
+  private let contentView = UIView()
+  
+  private let artworkImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFill
+    $0.clipsToBounds = true
+    $0.backgroundColor = .systemGreen
+  }
+  
+  private let closeButton = UIButton(type: .system).then {
+    $0.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+    $0.tintColor = .black
+
+  }
+  
+  private let infoContainerView = UIView().then {
+    $0.backgroundColor = .systemBackground
+  }
+  
+  private let genreLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 14, weight: .medium)
+    $0.textColor = .secondaryLabel
+  }
+  
+  private let collectionNameLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 24, weight: .bold)
+    $0.textColor = .label
+    $0.numberOfLines = 0
+  }
+  
+  private let contentRatingLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 18, weight: .semibold)
+    $0.textColor = .label
+  }
+  
+  private let artistNameLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 16, weight: .medium)
+    $0.textColor = .secondaryLabel
+  }
+  
+  private let trackNameLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 20, weight: .bold)
+    $0.textColor = .label
+    $0.numberOfLines = 0
+  }
+  
+  private let releaseDateLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 16, weight: .regular)
+    $0.textColor = .secondaryLabel
+  }
+  
+  private let descriptionLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 18, weight: .bold)
+    $0.textColor = .secondaryLabel
+    $0.numberOfLines = 0
+  }
+  
+  // MARK: - Initializers
+  
+  init(mediaItem: MediaItem, coordinator: AppCoordinator?) {
+    self.mediaItem = mediaItem
+    self.coordinator = coordinator
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Lifecycle
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupUI()
+    configureContent()
+  }
+  
+  // MARK: - Setup Methods
+  
+  private func setupUI() {
+    view.backgroundColor = .systemBackground
+    
+    view.addSubview(scrollView)
+    scrollView.addSubview(contentView)
+    
+    [artworkImageView, closeButton, infoContainerView]
+      .forEach { contentView.addSubview($0) }
+    
+    [genreLabel, collectionNameLabel, contentRatingLabel,
+     artistNameLabel, trackNameLabel, releaseDateLabel, descriptionLabel]
+      .forEach { infoContainerView.addSubview($0) }
+    
+    setupConstraints()
+    setupActions()
+  }
+  
+  private func setupConstraints() {
+    scrollView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    contentView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+      $0.width.equalToSuperview()
+      $0.height.greaterThanOrEqualTo(view.snp.height)
+    }
+    
+    artworkImageView.snp.makeConstraints {
+      $0.top.horizontalEdges.equalToSuperview()
+      $0.height.equalTo(view.snp.height).multipliedBy(0.6)
+    }
+    
+    closeButton.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+      $0.trailing.equalToSuperview().inset(16)
+      $0.width.height.equalTo(40)
+    }
+    
+    infoContainerView.snp.makeConstraints {
+      $0.top.equalTo(artworkImageView.snp.bottom).offset(-20)
+      $0.horizontalEdges.bottom.equalToSuperview()
+    }
+    
+    genreLabel.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(24)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+    }
+    
+    collectionNameLabel.snp.makeConstraints {
+      $0.top.equalTo(genreLabel.snp.bottom).offset(8)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+    }
+    
+    contentRatingLabel.snp.makeConstraints {
+      $0.top.equalTo(collectionNameLabel.snp.bottom).offset(8)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+    }
+    
+    artistNameLabel.snp.makeConstraints {
+      $0.top.equalTo(contentRatingLabel.snp.bottom).offset(8)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+    }
+    
+    trackNameLabel.snp.makeConstraints {
+      $0.top.equalTo(artistNameLabel.snp.bottom).offset(16)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+    }
+    
+    releaseDateLabel.snp.makeConstraints {
+      $0.top.equalTo(trackNameLabel.snp.bottom).offset(8)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+    }
+    
+    descriptionLabel.snp.makeConstraints {
+      $0.top.equalTo(releaseDateLabel.snp.bottom).offset(16)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+      $0.bottom.lessThanOrEqualToSuperview().inset(40)
+    }
+  }
+  
+  private func setupActions() {
+    closeButton.rx.tap
+      .bind(onNext: { [weak self] in
+        self?.coordinator?.dismissDetailScreen()
+      })
+      .disposed(by: disposeBag)
+  }
+  
+  // MARK: - Configuration
+  
+  private func configureContent() {
+    artworkImageView.loadLargeImage(from: mediaItem.artworkUrl)
+    
+    genreLabel.text = mediaItem.genre
+    collectionNameLabel.text = mediaItem.collectionName
+    artistNameLabel.text = mediaItem.artistName
+    trackNameLabel.text = mediaItem.trackName
+    releaseDateLabel.text = DateHelper.displayDate(from: mediaItem.releaseDate)
+    
+    configureMediaDetailContent()
+  }
+  
+  private func configureMediaDetailContent() {
+    switch mediaItem.mediaType {
+    case .music:
+      contentRatingLabel.isHidden = true
+      
+    case .movie:
+      if let movie = mediaItem as? Movie {
+        contentRatingLabel.text = movie.contentRating
+        descriptionLabel.text = movie.longDescription
+        contentRatingLabel.isHidden = movie.contentRating?.isEmpty != false
+      }
+      
+    case .podcast:
+      if let podcast = mediaItem as? Podcast {
+        genreLabel.text = podcast.genres.joined(separator: ", ")
+      }
+      contentRatingLabel.isHidden = true
+    }
+  }
+}

--- a/iTunesStore/Presentation/Views/Music/MusicViewController.swift
+++ b/iTunesStore/Presentation/Views/Music/MusicViewController.swift
@@ -45,6 +45,7 @@ class MusicViewController: UIViewController, View {
   override func viewDidLoad() {
     super.viewDidLoad()
     setupUI()
+    collectionView.delegate = self 
   }
   
   // MARK: - Setup Methods
@@ -282,5 +283,12 @@ extension MusicViewController {
       elementKind: UICollectionView.elementKindSectionHeader,
       alignment: .top
     )
+  }
+}
+
+extension MusicViewController: UICollectionViewDelegate {
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let musicItem = dataSource.itemIdentifier(for: indexPath) else { return }
+    coordinator?.showDetailScreen(mediaItem: musicItem.music)
   }
 }

--- a/iTunesStore/Presentation/Views/Search/MovieCell.swift
+++ b/iTunesStore/Presentation/Views/Search/MovieCell.swift
@@ -178,12 +178,6 @@ final class MovieCell: UICollectionViewCell {
     collectionNameLabel.text = movie.collectionName
     artistNameLabel.text = movie.artistName
     trackNameLabel.text = movie.trackName
-    
-    if let releaseDateString = movie.releaseDate {
-        let displayDate = String(releaseDateString.prefix(10))
-        releaseDateLabel.text = displayDate
-      } else {
-        releaseDateLabel.text = nil
-      }
+    releaseDateLabel.text = DateHelper.displayDate(from: movie.releaseDate)
   }
 }

--- a/iTunesStore/Presentation/Views/Search/PodcastCell.swift
+++ b/iTunesStore/Presentation/Views/Search/PodcastCell.swift
@@ -143,12 +143,6 @@ final class PodcastCell: UICollectionViewCell {
     
     collectionNameLabel.text = podcast.collectionName
     artistNameLabel.text = podcast.artistName
-    
-    if let releaseDateString = podcast.releaseDate {
-      let displayDate = String(releaseDateString.prefix(10))
-      releaseDateLabel.text = displayDate
-    } else {
-      releaseDateLabel.text = nil
-    }
+    releaseDateLabel.text = DateHelper.displayDate(from: podcast.releaseDate)
   }
 }

--- a/iTunesStore/Presentation/Views/Search/PodcastRowCell.swift
+++ b/iTunesStore/Presentation/Views/Search/PodcastRowCell.swift
@@ -8,8 +8,19 @@
 import SnapKit
 import Then
 import UIKit
+import RxSwift
+import RxCocoa
 
 final class PodcastRowCell: UICollectionViewCell {
+  
+  // MARK: - Properties
+  
+  var onFirstPodcastTap: ((Podcast) -> Void)?
+  var onSecondPodcastTap: ((Podcast) -> Void)?
+  
+  private var firstPodcast: Podcast?
+  private var secondPodcast: Podcast?
+  private var disposeBag = DisposeBag()
   
   // MARK: - UI Components
   
@@ -28,10 +39,20 @@ final class PodcastRowCell: UICollectionViewCell {
     super.init(frame: frame)
     setupUI()
     setupConstraints()
+    setupTapGestures()
   }
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag() // disposeBag 초기화
+    firstPodcast = nil
+    secondPodcast = nil
+    onFirstPodcastTap = nil
+    onSecondPodcastTap = nil
   }
   
   override func layoutSubviews() {
@@ -62,9 +83,38 @@ final class PodcastRowCell: UICollectionViewCell {
     }
   }
   
+  private func setupTapGestures() {
+    let firstTapGesture = UITapGestureRecognizer()
+    firstPodcastCell.addGestureRecognizer(firstTapGesture)
+    firstPodcastCell.isUserInteractionEnabled = true
+    
+    let secondTapGesture = UITapGestureRecognizer()
+    secondPodcastCell.addGestureRecognizer(secondTapGesture)
+    secondPodcastCell.isUserInteractionEnabled = true
+    
+    firstTapGesture.rx.event
+      .bind(onNext: { [weak self] _ in
+        guard let self = self,
+              let podcast = self.firstPodcast else { return }
+        self.onFirstPodcastTap?(podcast)
+      })
+      .disposed(by: disposeBag)
+    
+    secondTapGesture.rx.event
+      .bind(onNext: { [weak self] _ in
+        guard let self = self,
+              let podcast = self.secondPodcast else { return }
+        self.onSecondPodcastTap?(podcast)
+      })
+      .disposed(by: disposeBag)
+  }
+  
   // MARK: - Configuration
   
   func configure(first: Podcast, second: Podcast?) {
+    self.firstPodcast = first
+    self.secondPodcast = second
+    
     firstPodcastCell.configure(podcast: first)
     
     if let second = second {

--- a/iTunesStore/Presentation/Views/Search/SearchViewController.swift
+++ b/iTunesStore/Presentation/Views/Search/SearchViewController.swift
@@ -77,6 +77,7 @@ class SearchViewController: UIViewController, View {
   override func viewDidLoad() {
     super.viewDidLoad()
     setupUI()
+    collectionView.delegate = self
   }
   
   override func viewDidAppear(_ animated: Bool) {
@@ -161,9 +162,17 @@ class SearchViewController: UIViewController, View {
     }
     
     let podcastRowCellRegistration = UICollectionView.CellRegistration<PodcastRowCell, SearchResultRow> {
-      cell, indexPath, item in
+      [weak self] cell, indexPath, item in
       if case .podcastPair(let first, let second) = item {
         cell.configure(first: first, second: second)
+        
+        cell.onFirstPodcastTap = { [weak self] podcast in
+          self?.coordinator?.showDetailScreen(mediaItem: podcast)
+        }
+        
+        cell.onSecondPodcastTap = { [weak self] podcast in
+          self?.coordinator?.showDetailScreen(mediaItem: podcast)
+        }
       }
     }
     
@@ -313,6 +322,21 @@ extension SearchViewController {
       section.interGroupSpacing = 20
       
       return section
+    }
+  }
+}
+
+extension SearchViewController: UICollectionViewDelegate {
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let searchRow = dataSource.itemIdentifier(for: indexPath) else { return }
+    
+    switch searchRow {
+    case .movie(let movie):
+      coordinator?.showDetailScreen(mediaItem: movie)
+      
+    case .podcastPair:
+      // 셀 내부에서 처리
+      break
     }
   }
 }

--- a/iTunesStore/Utils/DateHelper.swift
+++ b/iTunesStore/Utils/DateHelper.swift
@@ -1,0 +1,14 @@
+//
+//  DateHelper.swift
+//  iTunesStore
+//
+//  Created by Milou on 8/4/25.
+//
+
+import Foundation
+
+struct DateHelper {
+  static func displayDate(from dateString: String?) -> String? {
+    return dateString.map { String($0.prefix(10)) }
+  }
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #8

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- AppCoordinator: 상세 화면 관련 메서드 추가
- DetailViewController: 음악, 영화, 팟캐스트의 상세 정보 보여주는 DetailViewController 추가
- MusicViewController/ SearchViewController: 아이템 선택 시 상세 화면으로 이동하는 로직 추가
- PodcastRowCell.swift: 두 개의 팟캐스트를 한 행에 보여주고, 각 아이템 탭 시 상세 화면으로 이동하도록 구현했습니다.
- /DTO, /Entity: 상세 화면에 필요한 데이터(longDescription, releaseDate 등) 추가 및 이에 따른 도메인 모델 수정
- DateHelper: 날짜 표시 형식을 통일하기 위한 DateHelper 추가


<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-04 at 18 05 35" src="https://github.com/user-attachments/assets/1e334184-1ce9-4f95-8aea-3e739b1b624f" />

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->

ID 값으로 콘텐츠 상세 정보를 다시 API 호출하여 상세 페이지를 구성하는 것이 이상적이지만, 시간이 많지 않아 현재 가지고 있는 데이터만 활용하여 화면을 구성. 추후 리팩토링 예정
